### PR TITLE
Add functionality to get filtered list of environments by dibs age

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ in the report:
 terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$'
 ```
 
-You can also use a flag, ```--older-than```, to further filter down environments by how old (in seconds) the dibs are:
+You can also use a flag, ```--older-than```, to further filter down environments that have been dibs'd for a given amount of time (in seconds):
 
 ```sh
 terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' --older-than=1800

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ in the report:
 terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$'
 ```
 
-You can also supply in seconds a filter to only see a list of environments that have been dibs'd for a certain amount of time:
+You can also use a flag, ```--older-than```, to further filter down environments by how old (in seconds) the dibs are:
 
 ```sh
-terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' 1800
+terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' --older-than=1800
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ in the report:
 terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$'
 ```
 
+You can also supply in seconds a filter to only see a list of environments that have been dibs'd for a certain amount of time:
+
+```sh
+terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' 1800
+```
+
+
 ## Use-cases
 
 This plugin assumes that you have persistent or semi-persistent environments

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$'
 You can also use a flag, ```--older-than```, to further filter down environments that have been dibs'd for a given amount of time (in seconds):
 
 ```sh
-terminus site:dibs:report tableau '^((?!^(dev|test|live)$).)*$' --older-than=1800
+terminus site:dibs:report your-site '^((?!^(dev|test|live)$).)*$' --older-than=1800
 ```
 
 

--- a/src/Commands/DibsCommand.php
+++ b/src/Commands/DibsCommand.php
@@ -114,7 +114,7 @@ class DibsCommand extends TerminusCommand implements SiteAwareInterface {
    * @param string $filter An optional regex pattern used to filter the pool of
    *   environments for which you wish to view the report.
    *
-   * @param integer $duration An optional time threshold (seconds) for duration that an environment has been dibs'd.
+   * @option integer $older-than An optional time threshold (seconds) for duration that an environment has been dibs'd.
    *
    * @return RowsOfFields
    *
@@ -126,13 +126,13 @@ class DibsCommand extends TerminusCommand implements SiteAwareInterface {
    *   by: By
    *   at: At
    *   message: Message
-   * @usage terminus site:dibs:report <site> [<filter>] [<duration>]
+   * @usage terminus site:dibs:report <site> [<filter>] --older-than
    *   Return a report of environments and their dibs status, optionally
    *   filtered by the <filter> regex pattern applied to environment names
-   *   and/or <duration> in seconds for how long a envrionment has been dibs'd.
+   *   and/or --older-than flag in seconds for how long a envrionment has been dibs'd.
    */
-  public function envDibsReport($site, $filter = '^((?!^live$).)*$', $duration = 0) {
-    return new RowsOfFields($this->getDibsReport($site, $filter, $duration));
+  public function envDibsReport($site, $filter = '^((?!^live$).)*$', $options = ['older-than' => 0,]) {
+    return new RowsOfFields($this->getDibsReport($site, $filter, $options));
   }
 
   /**
@@ -279,7 +279,7 @@ class DibsCommand extends TerminusCommand implements SiteAwareInterface {
       // Further filter report by the age the of the dibs if a threshold was set.
       $age = isset($dibs['at']) ? time() - isset($dibs['at']) : 0;
 
-      if ($age > $threshold || $threshold == 0) {
+      if ($age > $threshold['older-than'] || $threshold['older-than'] == 0) {
         $status[] = [
           'env' => $env,
           'status' => $envStatus,

--- a/src/Commands/DibsCommand.php
+++ b/src/Commands/DibsCommand.php
@@ -277,7 +277,7 @@ class DibsCommand extends TerminusCommand implements SiteAwareInterface {
       }
 
       // Further filter report by the age the of the dibs if a threshold was set.
-      $age = isset($dibs['at']) ? time() - isset($dibs['at']) : 0;
+      $age = isset($dibs['at']) ? time() - $dibs['at'] : 0;
 
       if ($age > $threshold['older-than'] || $threshold['older-than'] == 0) {
         $status[] = [


### PR DESCRIPTION
Add the ability to retrieve a filtered list of environments that have been dibs'd for a certain amount of time to envDibsReport. Defaults to reporting all environment statuses if no threshold was given. 

`terminus site:dibs:report <site> [<env-name-pattern>] [--older-than=<time in seconds>]`