### PR TITLE
Dibs plugin for Terminus 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,7 @@ environment to another), and will allow the target site to be dibs'd (like if
 `dev` was already dib's and you spun up `multidev-1` from `dev`, even though the
 dibs JSON from `dev` would exist on `multidev-1`, this plugin will still allow
 you to call dibs on `multidev-1` anyway).
+
+## Notes
+- Compatibility with [`terminus 2.0.x`](https://github.com/pantheon-systems/terminus/releases/tag/2.0.0):
+    - 1.x versions of Dibs is compatible with `1.x` up to `2.0.0` versions of Terminus.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "extra": {
     "terminus": {
-      "compatible-version": "^2.0"
+      "compatible-version": "^1|^2"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "extra": {
     "terminus": {
-      "compatible-version": "^1"
+      "compatible-version": "^2.0"
     }
   }
 }


### PR DESCRIPTION
## What? Why?

Terminus is onto version 2.0, this change allows dibs plugin to be used with terminus ^2.0 via a change to composer.json.


## QA / testing
* Updated local terminus version to `2.0.0`
* Installed dibs locally and ran commands below without hiccup against a Pantheon site:
- `terminus  site:dibs:report`
- `terminus site:dibs`
- `terminus env:dibs`
- `terminus env:undibs`
 